### PR TITLE
adding environment setup script and instructions in readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 .vscode/
 .*.swp
+.venv/
 
 run_vjepa_aws.py
 run.py

--- a/README.md
+++ b/README.md
@@ -285,10 +285,18 @@ To run this notebook, you'll need to aditionally install [Jupyter](https://jupyt
 
 ### Setup
 
-```
+```bash
 conda create -n vjepa2-312 python=3.12
 conda activate vjepa2-312
 pip install .  # or `pip install -e .` for development mode
+```
+
+### Alternative Setup
+
+If you are a developer working on a mac or linux machine, you can use the following script to setup your environment. It will create a virtual environment with Python 3.11 and install all dependencies. This approach gracefully handles the installation of decord on Apple Silicon, which would otherwise prevent setup with a conda environment on python 3.12.
+
+```bash
+./bin/developer_setup.sh
 ```
 
 ### Usage Demo

--- a/bin/developer_setup.sh
+++ b/bin/developer_setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# Check if uv is installed
+if ! command -v uv &> /dev/null
+then
+    echo "uv could not be found. Please install it first."
+    echo "See: https://github.com/astral-sh/uv"
+    exit
+fi
+
+# Create virtual environment with a specific python version
+uv venv .venv -p python3.11
+source .venv/bin/activate
+
+# Check for macOS on ARM
+if [[ "$(uname)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
+    echo "macOS on ARM detected. Installing decord using the recommended method..."
+    uv pip install eva-decord
+
+    echo "Installing other dependencies from requirements.txt..."
+    grep -v '^decord' requirements.txt > requirements.tmp
+    uv pip install -r requirements.tmp --prerelease=allow
+    rm requirements.tmp
+else
+    echo "Installing all dependencies from requirements.txt..."
+    uv pip install -r requirements.txt --prerelease=allow
+fi
+
+echo "Developer setup complete. Virtual environment created at ./.venv with Python 3.11."
+echo "To activate it, run: source .venv/bin/activate" 


### PR DESCRIPTION
This change add a script that can be run to setup the development environment for the project in a `.venv` folder created using `uv`.  It gracefully accounts for the lack of Apple Silicon support in the `decord` package, which would otherwise prevent users from setting up their environment with the provided instructions.