### PR TITLE
Replace AutoVideoProcessor with AutoImageProcessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ hf_repo = "facebook/vjepa2-vitg-fpc64-256"
 
 
 model = AutoModel.from_pretrained(hf_repo)
-processor = AutoVideoProcessor.from_pretrained(hf_repo)
+processor = AutoImageProcessor.from_pretrained(hf_repo)
 ```
 
 #### Evaluation Attentive Probes


### PR DESCRIPTION
The Pretained checkpoints on Huggingface section has an error where the AutoVideoProcessor was used instead of AutoImageProcessor in example.