### PR TITLE
Use repeat_interleave for RoPE frequency expansion in rotate_queries_…

### DIFF
--- a/src/models/utils/modules.py
+++ b/src/models/utils/modules.py
@@ -37,8 +37,8 @@ def rotate_queries_or_keys(x, pos):
     emb_sin = freq.sin()  # (..., N, D/2)
     emb_cos = freq.cos()  # (..., N, D/2)
 
-    emb_sin = emb_sin.squeeze(-1).repeat(1, 1, 1, 2)
-    emb_cos = emb_cos.squeeze(-1).repeat(1, 1, 1, 2)
+    emb_sin = emb_sin.repeat_interleave(2, dim=-1)  # (..., N, D)
+    emb_cos = emb_cos.repeat_interleave(2, dim=-1)  # (..., N, D)
 
     # --
     y = x.unflatten(-1, (-1, 2))


### PR DESCRIPTION

Previously, we used `.repeat(1,1,1,2)` to expand our RoPE sin/cos embeddings, which duplicated each frequency across its vector pair. This is a subtle bug.

This change replaces that pattern with a direct `repeat_interleave(2, dim=-1)`, ensuring that each θᵢ is exactly duplicated for both dimensions of its 2×2 rotation block:

- Before: `repeat(1,1,1,2)`  
- After:  `repeat_interleave(2, dim=-1)`

By interleaving correctly, we guarantee proper alignment of all coordinate pairs during the complex rotation.