### PR TITLE
Edited the demo colab notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ pip install .  # or `pip install -e .` for development mode
 
 ### Usage Demo
 
-See [vjepa2_demo.ipynb](notebooks/vjepa2_demo.ipynb) [(Colab Link)](https://colab.research.google.com/github/facebookresearch/vjepa2/blob/main/notebooks/vjepa2_demo.ipynb) or [vjepa2_demo.py](notebooks/vjepa2_demo.py) for an example of how to load both the HuggingFace and PyTorch V-JEPA 2 models and run inference on a sample video to get a sample classification result.
+See [vjepa2_demo.ipynb](notebooks/vjepa2_demo.ipynb) [(Colab Link)](https://colab.research.google.com/github/ShreeshaBhat1004/storage/blob/main/notebooks/vjepa2_demo.ipynb) or [vjepa2_demo.py](notebooks/vjepa2_demo.py) for an example of how to load both the HuggingFace and PyTorch V-JEPA 2 models and run inference on a sample video to get a sample classification result.
 
 The script assumes the presence of downloaded model checkpoints so you will need to download the model weights and update the corresponding paths in the script. E.g.:
 ```


### PR DESCRIPTION
Key changes: 
- Install latest commit of transformers library, because AutoModel and AutoVisualModel use latest commit of transformers. 
- Instructions to clone the vjepa2 repository to address, `no module named 'src' was found` error