### PR TITLE
Updates requirements.txt to decord2 to support OSX

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ webdataset
 timm
 transformers
 peft
-decord
+decord2
 pandas
 einops
 beartype


### PR DESCRIPTION
Per the README, Python 3.12 is installed as a conda env, so this assumes a Python 3.12 environment.

There is potentially a conflict with another solution proposed in #22 .
But this has been tested on both OSX and Linux (arm64), and the repo package can build and install.
(running on OSX requires other changes as CUDA is assumed in the current implementation)

On OSX/Darwin, `decord` does not have a package in PyPI:
```
$ curl -s https://pypi.org/pypi/decord/json | \
> jq '.releases["0.6.0"][].filename'
"decord-0.6.0-cp36-cp36m-macosx_10_15_x86_64.whl"
"decord-0.6.0-cp37-cp37m-macosx_10_15_x86_64.whl"
"decord-0.6.0-cp38-cp38-macosx_10_15_x86_64.whl"
"decord-0.6.0-py3-none-manylinux2010_x86_64.whl"
"decord-0.6.0-py3-none-win_amd64.whl"
```

However, `decord2` does:
```
$ curl -s https://pypi.org/pypi/decord2/json | jq '.releases["1.0.0"][].filename'
"decord2-1.0.0-cp310-cp310-macosx_12_0_arm64.whl"
"decord2-1.0.0-cp310-cp310-macosx_12_0_x86_64.whl"
"decord2-1.0.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl"
"decord2-1.0.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
"decord2-1.0.0-cp311-cp311-macosx_12_0_arm64.whl"
"decord2-1.0.0-cp311-cp311-macosx_12_0_x86_64.whl"
"decord2-1.0.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl"
"decord2-1.0.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
"decord2-1.0.0-cp312-cp312-macosx_12_0_arm64.whl"
"decord2-1.0.0-cp312-cp312-macosx_12_0_x86_64.whl"
"decord2-1.0.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl"
"decord2-1.0.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
"decord2-1.0.0-cp313-cp313-macosx_12_0_arm64.whl"
"decord2-1.0.0-cp313-cp313-macosx_12_0_x86_64.whl"
"decord2-1.0.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl"
"decord2-1.0.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
```

And `decord2` appears to export the same interface, so everything works without other changes.

