### PR TITLE
fix: correct CSV logger column headers to match logged data

### DIFF
--- a/evals/video_classification_frozen/eval.py
+++ b/evals/video_classification_frozen/eval.py
@@ -133,7 +133,7 @@ def main(args_eval, resume_preempt=False):
 
     # -- make csv_logger
     if rank == 0:
-        csv_logger = CSVLogger(log_file, ("%d", "epoch"), ("%.5f", "loss"), ("%.5f", "acc"))
+        csv_logger = CSVLogger(log_file, ("%d", "epoch"), ("%.5f", "train_acc"), ("%.5f", "val_acc"))
 
     # Initialize model
 


### PR DESCRIPTION
- Change 'loss' column to 'train_acc'
- Change 'acc' column to 'val_acc'
- Headers now accurately reflect train_acc and val_acc values being logged