### PR TITLE
Add preserve_border flag to vjepa2_preprocessor (default off) to avoid extra border trimming during eval

### DIFF
--- a/evals/hub/preprocessor.py
+++ b/evals/hub/preprocessor.py
@@ -4,12 +4,12 @@
 # LICENSE file in the root directory of this source tree.
 
 
-def _make_transforms(crop_size=256):
+def _make_transforms(crop_size=256, preserve_border=False):
     from ..video_classification_frozen.utils import make_transforms
 
-    return make_transforms(crop_size=crop_size, training=False)
+    return make_transforms(crop_size=crop_size, training=False, preserve_border=preserve_border)
 
 
-def vjepa2_preprocessor(*, pretrained: bool = True, **kwargs):
+def vjepa2_preprocessor(*, pretrained: bool = True, preserve_border: bool = False, **kwargs):
     crop_size = kwargs.get("crop_size", 256)
-    return _make_transforms(crop_size=crop_size)
+    return _make_transforms(crop_size=crop_size, preserve_border=preserve_border)

--- a/evals/video_classification_frozen/utils.py
+++ b/evals/video_classification_frozen/utils.py
@@ -23,6 +23,7 @@ def make_transforms(
     crop_size=224,
     num_views_per_clip=1,
     normalize=((0.485, 0.456, 0.406), (0.229, 0.224, 0.225)),
+    preserve_border=False
 ):
 
     if not training and num_views_per_clip > 1:
@@ -44,6 +45,7 @@ def make_transforms(
             motion_shift=motion_shift,
             crop_size=crop_size,
             normalize=normalize,
+            preserve_border=preserve_border
         )
     return _frames_augmentation
 
@@ -61,11 +63,12 @@ class VideoTransform(object):
         motion_shift=False,
         crop_size=224,
         normalize=((0.485, 0.456, 0.406), (0.229, 0.224, 0.225)),
+        preserve_border=False
     ):
 
         self.training = training
 
-        short_side_size = int(crop_size * 256 / 224)
+        short_side_size = int(crop_size * 256 / 224) if not preserve_border else crop_size
         self.eval_transform = video_transforms.Compose(
             [
                 video_transforms.Resize(short_side_size, interpolation="bilinear"),


### PR DESCRIPTION
**Summary**

Introduce a boolean flag preserve_border in vjepa2_preprocessor (default: False).
When set to True, the eval resize step uses short_side_size = crop_size instead of the ImageNet-style crop_size * 256/224, which otherwise guarantees extra border pixels are trimmed by the subsequent CenterCrop.

Default behavior is unchanged.

**Motivation**

The current eval transform:

> short_side_size = int(crop_size * 256 / 224)
Resize(short_side_size) → CenterCrop(crop_size) → ClipToTensor → Normalize

always resizes the short side to a size larger than the crop_size(e.g., 256→292) and then center-crops back to crop_size, discarding border pixels.
Some downstream video tasks are sensitive to peripheral content. preserve_border=True avoids this fixed extra trimming while keeping the output shape the same.

**Change**
- Add preserve_border: bool = False to vjepa2_preprocessor.
- If preserve_border is True, set short_side_size = crop_size; otherwise keep the existing *256/224 rule.

**Minimal diff**
The key change is in evals/video_classification_frozen/utils.py:

```
-    short_side_size = int(crop_size * 256 / 224)
+    short_side_size = int(crop_size * 256 / 224) if not preserve_border else crop_size
```

**Usage**

```
# Old behavior (default, for strict reproduction of prior results)
aug = vjepa2_preprocessor(crop_size=256)

# Preserve borders on the short side (avoid the extra upscaling/crop)
aug = vjepa2_preprocessor(crop_size=256, preserve_border=True)
```

**Impact**
- Backward compatible by default: leaving preserve_border=False keeps identical results.
- Opt-in (True) may slightly shift metrics due to less trimming; final tensor shapes remain [C, T, crop_size, crop_size].
