### PR TITLE
README.md: fixing incorrect link for Jupyter notebook (returns 404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ vjepa2_encoder, vjepa2_ac_predictor = torch.hub.load('facebookresearch/vjepa2', 
 ```
 
 
-See [energy_landscape_example.ipynb](notebooks/vjepa_droid/energy_landscape.ipynb) for an example notebook computing the energy landscape of the pretrained action-conditioned backbone using a robot trajectory collected from our lab.
+See [energy_landscape_example.ipynb](notebooks/energy_landscape_example.ipynb) for an example notebook computing the energy landscape of the pretrained action-conditioned backbone using a robot trajectory collected from our lab.
 To run this notebook, you'll need to additionally install [Jupyter](https://jupyter.org/install) and [Scipy](https://scipy.org/install/) in your conda environment.
 
 


### PR DESCRIPTION
Hi,
The link in README.md for the example Jupyter notebook is currently incorrect: it currently returns HTTP 404.
This PR fixes it.


Regards,
Didier