### PR TITLE
Fix: forward drop_last to make_videodataset

### DIFF
--- a/src/datasets/data_manager.py
+++ b/src/datasets/data_manager.py
@@ -81,6 +81,7 @@ def init_data(
             num_workers=num_workers,
             pin_mem=pin_mem,
             persistent_workers=persistent_workers,
+            drop_last=drop_last,
             world_size=world_size,
             rank=rank,
             deterministic=deterministic,

--- a/src/datasets/video_dataset.py
+++ b/src/datasets/video_dataset.py
@@ -348,15 +348,10 @@ class VideoDataset(torch.utils.data.Dataset):
                 # If partition overlap is allowed and partition_len < clip_len
                 # then start_indx of segment i+1 will lie within segment i
                 else:
-                    sample_len = min(clip_len, len(vr)) - 1
-                    indices = np.linspace(0, sample_len, num=sample_len // fstp)
-                    indices = np.concatenate(
-                        (
-                            indices,
-                            np.ones(fpc - sample_len // fstp) * sample_len,
-                        )
-                    )
-                    indices = np.clip(indices, 0, sample_len - 1).astype(np.int64)
+                    max_idx = min(clip_len, len(vr)) - 1
+                    indices = np.clip(
+                        np.arange(fpc) * fstp, 0, max_idx
+                    ).astype(np.int64)
                     # --
                     clip_step = 0
                     if len(vr) > clip_len:


### PR DESCRIPTION
The drop_last argument was not passed to make_videodataset(), which results in default behavior to drop remainder samples in case of validation dataset. This is more significant in case of small datasets.

 This one-liner fixes this issue.