### PR TITLE
Bump black to 26.3.1

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 # Tools for static checking.
-black == 24.4.2
+black == 26.3.1
 flake8 == 7.0.0
 isort == 5.13.2


### PR DESCRIPTION
~~Addresses a security vulnerability in previous versions of `black`~~ (duplicate of #127)
