### PR TITLE
Update paper link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ V-JEPA 2 is a self-supervised approach to training video encoders, using interne
 Lorenzo Mur-Labadia, Matthew Muckley, Amir Bar, Mahmoud Assran, Koustuv Sinha, Michael
 Rabbat, Yann LeCun, Nicolas Ballas, Adrien Bardes
 
-[[`Paper`](https://arxiv.org/abs/TODO)] [[`BibTex`](#Citation)]
+[[`Paper`](https://arxiv.org/abs/2603.14482)] [[`BibTex`](#Citation)]
 
 V-JEPA 2.1 improves the training recipe to focus on learning high-quality and temporally consistent dense features, as higlighted by PCA visualizations:
 


### PR DESCRIPTION
The link of [Paper] referred in [heading](https://github.com/facebookresearch/vjepa2?tab=readme-ov-file#v-jepa-21-pre-training:~:text=training%20or%20calibration.-,V%2DJEPA%202.1%20Pre%2Dtraining,-Lorenzo%20Mur%2DLabadia) is broken as its leading to "https://arxiv.org/abs/TODO" instead to "https://arxiv.org/abs/2603.14482"

add Fixes #141 