### PR TITLE
Fix SDPA dropout during eval

### DIFF
--- a/app/vjepa_2_1/models/utils/modules.py
+++ b/app/vjepa_2_1/models/utils/modules.py
@@ -285,7 +285,7 @@ class RoPEAttention(nn.Module):
         if self.use_sdpa:
             with torch.backends.cuda.sdp_kernel():
                 x = F.scaled_dot_product_attention(
-                    q, k, v, dropout_p=self.proj_drop_prob, is_causal=self.is_causal
+                    q, k, v, dropout_p=self.proj_drop_prob if self.training else 0.0, is_causal=self.is_causal
                 )
                 attn = None
         else:
@@ -338,7 +338,7 @@ class Attention(nn.Module):
         if self.use_sdpa:
             with torch.backends.cuda.sdp_kernel():
                 x = F.scaled_dot_product_attention(
-                    q, k, v, dropout_p=self.proj_drop_prob, is_causal=self.is_causal
+                    q, k, v, dropout_p=self.proj_drop_prob if self.training else 0.0, is_causal=self.is_causal
                 )
                 attn = None
         else:

--- a/src/models/utils/modules.py
+++ b/src/models/utils/modules.py
@@ -248,7 +248,8 @@ class ACRoPEAttention(nn.Module):
         if attn_mask is not None or self.use_sdpa:
             with torch.backends.cuda.sdp_kernel():
                 x = F.scaled_dot_product_attention(
-                    q, k, v, dropout_p=self.proj_drop_prob, is_causal=self.is_causal, attn_mask=attn_mask
+                    q, k, v, dropout_p=self.proj_drop_prob if self.training else 0.0,
+                    is_causal=self.is_causal, attn_mask=attn_mask
                 )
                 attn = None
         else:
@@ -372,7 +373,8 @@ class RoPEAttention(nn.Module):
         if attn_mask is not None or self.use_sdpa:
             with torch.backends.cuda.sdp_kernel():
                 x = F.scaled_dot_product_attention(
-                    q, k, v, dropout_p=self.proj_drop_prob, is_causal=self.is_causal, attn_mask=attn_mask
+                    q, k, v, dropout_p=self.proj_drop_prob if self.training else 0.0,
+                    is_causal=self.is_causal, attn_mask=attn_mask
                 )
                 attn = None
         else:
@@ -419,7 +421,8 @@ class Attention(nn.Module):
         if attn_mask is not None or self.use_sdpa:
             with torch.backends.cuda.sdp_kernel():
                 x = F.scaled_dot_product_attention(
-                    q, k, v, dropout_p=self.proj_drop_prob, is_causal=self.is_causal, attn_mask=attn_mask
+                    q, k, v, dropout_p=self.proj_drop_prob if self.training else 0.0,
+                    is_causal=self.is_causal, attn_mask=attn_mask
                 )
                 attn = None
         else:


### PR DESCRIPTION
`F.scaled_dot_product_attention` applies dropout whenever `dropout_p > 0`, even when the module is in eval mode.

This does not affect the default pretrained V-JEPA 2.1 inference because dropout defaults to `0.0`, but if the attention modules are configured with nonzero `proj_drop`, eval can produce different outputs.

This PR sets the `dropout_p` argument to zero when `self.training` is false, matching the usual behavior.