### PR TITLE
Add vjepa2_doctor for checkpoint/config validation before continued pretrain

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,18 @@ vjepa2_1_vit_gigantic_384 = torch.hub.load('facebookresearch/vjepa2', 'vjepa2_1_
 
 ```
 
+#### Checkpoint/config doctor (continued pretraining)
+
+Before continuing pretraining from a released V-JEPA 2.1 checkpoint, validate that your YAML `crop_size`, `pred_depth`, and `embed_dim` match the checkpoint — mismatches can cause silent partial loads or NaN loss ([#163](https://github.com/facebookresearch/vjepa2/issues/163)).
+
+```bash
+python scripts/vjepa2_doctor.py \
+  --checkpoint path/to/vjepa2_1_vitl_dist_vitG_384.pt \
+  --config configs/train_2_1/vitl16/cooldown-256px-64f.yaml
+```
+
+Add `--json` for machine-readable output. Exits non-zero on failure.
+
 #### Pretrained checkpoints on Huggingface
 
 You can also use our pretrained checkpoints on [Huggingface for V-JEPA 2](https://huggingface.co/collections/facebook/v-jepa-2-6841bad8413014e185b497a6).

--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ python scripts/vjepa2_doctor.py \
 
 Add `--json` for machine-readable output. Exits non-zero on failure.
 
+> **Security:** Only run this tool on checkpoint files from trusted sources (official Meta releases or your own training runs). The doctor may fall back to `torch.load(..., weights_only=False)` when a checkpoint contains custom classes; deserializing untrusted pickle payloads can execute arbitrary code. Do not point it at user uploads in CI without sandboxing.
+
 #### Pretrained checkpoints on Huggingface
 
 You can also use our pretrained checkpoints on [Huggingface for V-JEPA 2](https://huggingface.co/collections/facebook/v-jepa-2-6841bad8413014e185b497a6).

--- a/scripts/vjepa2_doctor.py
+++ b/scripts/vjepa2_doctor.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+"""Validate V-JEPA 2.1 checkpoint metadata against a training YAML config.
+
+Addresses silent failures when continuing pretraining with mismatched crop_size,
+pred_depth, or encoder keys (see facebookresearch/vjepa2#163, #149).
+
+Usage:
+  python scripts/vjepa2_doctor.py --checkpoint path/to.ckpt --config path/to.yaml
+  python scripts/vjepa2_doctor.py --checkpoint path/to.ckpt --config path/to.yaml --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+import torch
+import yaml
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    with path.open() as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"expected mapping in {path}")
+    return data
+
+
+def _nested_get(cfg: dict[str, Any], *keys: str, default: Any = None) -> Any:
+    cur: Any = cfg
+    for key in keys:
+        if not isinstance(cur, dict) or key not in cur:
+            return default
+        cur = cur[key]
+    return cur
+
+
+def count_predictor_blocks(predictor_state: dict[str, Any]) -> int | None:
+    indices: set[int] = set()
+    for key in predictor_state:
+        if "blocks." in key or "predictor_blocks." in key:
+            parts = key.split(".")
+            for i, part in enumerate(parts):
+                if part in ("blocks", "predictor_blocks") and i + 1 < len(parts):
+                    if parts[i + 1].isdigit():
+                        indices.add(int(parts[i + 1]))
+    if not indices:
+        return None
+    return max(indices) + 1
+
+
+def infer_embed_dim(state: dict[str, Any]) -> int | None:
+    for key, tensor in state.items():
+        if "pos_embed" in key and hasattr(tensor, "shape") and len(tensor.shape) >= 2:
+            return int(tensor.shape[-1])
+    return None
+
+
+def infer_crop_size(state: dict[str, Any], *, patch_size: int = 16) -> int | None:
+    """Infer spatial crop from encoder pos_embed patch grid (image or tubelets)."""
+    for key, tensor in state.items():
+        if "pos_embed" not in key or not hasattr(tensor, "shape"):
+            continue
+        if len(tensor.shape) != 3:
+            continue
+        num_tokens = int(tensor.shape[1])
+        # drop cls token if present (common N+1 layouts)
+        for n in (num_tokens, num_tokens - 1):
+            side = int(math.isqrt(n))
+            if side * side == n and side > 0:
+                return side * patch_size
+    return None
+
+
+def inspect_checkpoint(path: Path, *, patch_size: int = 16) -> dict[str, Any]:
+    ckpt = torch.load(path, map_location="cpu", weights_only=False)
+    if not isinstance(ckpt, dict):
+        raise ValueError(f"expected dict checkpoint at {path}")
+
+    encoder = ckpt.get("ema_encoder") or ckpt.get("encoder") or {}
+    predictor = ckpt.get("predictor") or {}
+
+    return {
+        "path": str(path),
+        "top_level_keys": sorted(ckpt.keys()),
+        "has_ema_encoder": "ema_encoder" in ckpt,
+        "has_target_encoder": "target_encoder" in ckpt,
+        "pred_depth": count_predictor_blocks(predictor if isinstance(predictor, dict) else {}),
+        "embed_dim": infer_embed_dim(encoder if isinstance(encoder, dict) else {}),
+        "crop_size": infer_crop_size(encoder if isinstance(encoder, dict) else {}, patch_size=patch_size),
+    }
+
+
+def run_doctor(
+    checkpoint: Path,
+    config: Path,
+    *,
+    patch_size: int | None = None,
+) -> dict[str, Any]:
+    cfg = _load_yaml(config)
+    patch = patch_size or int(_nested_get(cfg, "model", "patch_size", default=16) or 16)
+    meta = inspect_checkpoint(checkpoint, patch_size=patch)
+
+    expected_crop = _nested_get(cfg, "data", "crop_size") or cfg.get("crop_size")
+    expected_depth = _nested_get(cfg, "model", "pred_depth") or cfg.get("pred_depth")
+    expected_embed = _nested_get(cfg, "model", "embed_dim") or cfg.get("embed_dim")
+
+    gates: list[dict[str, Any]] = []
+
+    if expected_crop is not None and meta["crop_size"] is not None:
+        ok = int(expected_crop) == int(meta["crop_size"])
+        gates.append(
+            {
+                "name": "crop_size",
+                "passed": ok,
+                "detail": f"config={expected_crop} checkpoint≈{meta['crop_size']} (from pos_embed)",
+            }
+        )
+    else:
+        gates.append(
+            {
+                "name": "crop_size",
+                "passed": True,
+                "detail": "skipped — missing crop_size in config or could not infer from checkpoint",
+                "skipped": True,
+            }
+        )
+
+    if expected_depth is not None and meta["pred_depth"] is not None:
+        ok = int(expected_depth) == int(meta["pred_depth"])
+        gates.append(
+            {
+                "name": "pred_depth",
+                "passed": ok,
+                "detail": f"config={expected_depth} checkpoint blocks={meta['pred_depth']}",
+            }
+        )
+    else:
+        gates.append(
+            {
+                "name": "pred_depth",
+                "passed": True,
+                "detail": "skipped — missing pred_depth in config or checkpoint",
+                "skipped": True,
+            }
+        )
+
+    if expected_embed is not None and meta["embed_dim"] is not None:
+        ok = int(expected_embed) == int(meta["embed_dim"])
+        gates.append(
+            {
+                "name": "embed_dim",
+                "passed": ok,
+                "detail": f"config={expected_embed} checkpoint={meta['embed_dim']}",
+            }
+        )
+    else:
+        gates.append(
+            {
+                "name": "embed_dim",
+                "passed": True,
+                "detail": "skipped — missing embed_dim in config or checkpoint",
+                "skipped": True,
+            }
+        )
+
+    if meta["has_ema_encoder"] and not meta["has_target_encoder"]:
+        gates.append(
+            {
+                "name": "checkpoint_keys",
+                "passed": True,
+                "detail": "checkpoint uses ema_encoder (distilled release) — map to target_encoder when loading",
+                "warn": True,
+            }
+        )
+
+    active = [g for g in gates if not g.get("skipped")]
+    passed = all(g["passed"] for g in active) if active else True
+
+    return {
+        "checkpoint": meta,
+        "config": str(config.resolve()),
+        "gates": gates,
+        "passed": passed,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="V-JEPA 2.1 checkpoint/config doctor")
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = run_doctor(args.checkpoint, args.config)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(f"V-JEPA 2.1 doctor — {'PASS' if report['passed'] else 'FAIL'}")
+        for g in report["gates"]:
+            mark = "PASS" if g["passed"] else "FAIL"
+            if g.get("skipped"):
+                mark = "SKIP"
+            print(f"  [{mark}] {g['name']}: {g['detail']}")
+
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vjepa2_doctor.py
+++ b/scripts/vjepa2_doctor.py
@@ -8,6 +8,10 @@ pred_depth, or encoder keys (see facebookresearch/vjepa2#163, #149).
 Usage:
   python scripts/vjepa2_doctor.py --checkpoint path/to.ckpt --config path/to.yaml
   python scripts/vjepa2_doctor.py --checkpoint path/to.ckpt --config path/to.yaml --json
+
+Security:
+  Only inspect checkpoint files from trusted sources. PyTorch deserialization can
+  execute arbitrary code when ``weights_only=False`` is required.
 """
 
 from __future__ import annotations
@@ -16,11 +20,16 @@ import argparse
 import json
 import math
 import sys
+import warnings
 from pathlib import Path
 from typing import Any
 
 import torch
 import yaml
+
+_ALLOWED_CHECKPOINT_SUFFIXES = {".pt", ".pth", ".ckpt"}
+# PyTorch zip-serialized checkpoints begin with PK; legacy pickles often begin with \x80.
+_CHECKPOINT_MAGIC_PREFIXES = (b"PK", b"\x80", b"\x82")
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -38,6 +47,57 @@ def _nested_get(cfg: dict[str, Any], *keys: str, default: Any = None) -> Any:
             return default
         cur = cur[key]
     return cur
+
+
+def _get_config_value(
+    cfg: dict[str, Any],
+    *nested_keys: str,
+    flat_key: str | None = None,
+) -> Any:
+    """Read nested config value; fall back to top-level only when nested is missing."""
+    value = _nested_get(cfg, *nested_keys)
+    if value is None and flat_key is not None:
+        value = cfg.get(flat_key)
+    return value
+
+
+def _safe_int(value: Any, *, field: str) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid {field}: {value!r} (expected integer)") from exc
+
+
+def _validate_checkpoint_path(path: Path) -> None:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    if path.suffix.lower() not in _ALLOWED_CHECKPOINT_SUFFIXES:
+        raise ValueError(
+            f"unsupported checkpoint extension {path.suffix!r}; "
+            f"expected one of {sorted(_ALLOWED_CHECKPOINT_SUFFIXES)}"
+        )
+    with path.open("rb") as f:
+        header = f.read(2)
+    if header and not any(header.startswith(prefix) for prefix in _CHECKPOINT_MAGIC_PREFIXES):
+        raise ValueError(
+            f"{path} does not look like a PyTorch checkpoint (unexpected file header)"
+        )
+
+
+def _load_checkpoint_dict(path: Path) -> dict[str, Any]:
+    _validate_checkpoint_path(path)
+    try:
+        ckpt = torch.load(path, map_location="cpu", weights_only=True)
+    except Exception:
+        warnings.warn(
+            f"{path}: weights_only=True failed; falling back to weights_only=False. "
+            "Only use checkpoints from trusted sources.",
+            stacklevel=2,
+        )
+        ckpt = torch.load(path, map_location="cpu", weights_only=False)
+    if not isinstance(ckpt, dict):
+        raise ValueError(f"expected dict checkpoint at {path}")
+    return ckpt
 
 
 def count_predictor_blocks(predictor_state: dict[str, Any]) -> int | None:
@@ -77,12 +137,17 @@ def infer_crop_size(state: dict[str, Any], *, patch_size: int = 16) -> int | Non
     return None
 
 
-def inspect_checkpoint(path: Path, *, patch_size: int = 16) -> dict[str, Any]:
-    ckpt = torch.load(path, map_location="cpu", weights_only=False)
-    if not isinstance(ckpt, dict):
-        raise ValueError(f"expected dict checkpoint at {path}")
+def _encoder_state(ckpt: dict[str, Any]) -> dict[str, Any]:
+    for key in ("ema_encoder", "encoder", "target_encoder"):
+        state = ckpt.get(key)
+        if isinstance(state, dict):
+            return state
+    return {}
 
-    encoder = ckpt.get("ema_encoder") or ckpt.get("encoder") or {}
+
+def inspect_checkpoint(path: Path, *, patch_size: int = 16) -> dict[str, Any]:
+    ckpt = _load_checkpoint_dict(path)
+    encoder = _encoder_state(ckpt)
     predictor = ckpt.get("predictor") or {}
 
     return {
@@ -91,8 +156,8 @@ def inspect_checkpoint(path: Path, *, patch_size: int = 16) -> dict[str, Any]:
         "has_ema_encoder": "ema_encoder" in ckpt,
         "has_target_encoder": "target_encoder" in ckpt,
         "pred_depth": count_predictor_blocks(predictor if isinstance(predictor, dict) else {}),
-        "embed_dim": infer_embed_dim(encoder if isinstance(encoder, dict) else {}),
-        "crop_size": infer_crop_size(encoder if isinstance(encoder, dict) else {}, patch_size=patch_size),
+        "embed_dim": infer_embed_dim(encoder),
+        "crop_size": infer_crop_size(encoder, patch_size=patch_size),
     }
 
 
@@ -103,17 +168,18 @@ def run_doctor(
     patch_size: int | None = None,
 ) -> dict[str, Any]:
     cfg = _load_yaml(config)
-    patch = patch_size or int(_nested_get(cfg, "model", "patch_size", default=16) or 16)
+    patch_raw = patch_size if patch_size is not None else _get_config_value(cfg, "model", "patch_size")
+    patch = _safe_int(patch_raw if patch_raw is not None else 16, field="model.patch_size")
     meta = inspect_checkpoint(checkpoint, patch_size=patch)
 
-    expected_crop = _nested_get(cfg, "data", "crop_size") or cfg.get("crop_size")
-    expected_depth = _nested_get(cfg, "model", "pred_depth") or cfg.get("pred_depth")
-    expected_embed = _nested_get(cfg, "model", "embed_dim") or cfg.get("embed_dim")
+    expected_crop = _get_config_value(cfg, "data", "crop_size", flat_key="crop_size")
+    expected_depth = _get_config_value(cfg, "model", "pred_depth", flat_key="pred_depth")
+    expected_embed = _get_config_value(cfg, "model", "embed_dim", flat_key="embed_dim")
 
     gates: list[dict[str, Any]] = []
 
     if expected_crop is not None and meta["crop_size"] is not None:
-        ok = int(expected_crop) == int(meta["crop_size"])
+        ok = _safe_int(expected_crop, field="crop_size") == _safe_int(meta["crop_size"], field="crop_size")
         gates.append(
             {
                 "name": "crop_size",
@@ -132,7 +198,9 @@ def run_doctor(
         )
 
     if expected_depth is not None and meta["pred_depth"] is not None:
-        ok = int(expected_depth) == int(meta["pred_depth"])
+        ok = _safe_int(expected_depth, field="pred_depth") == _safe_int(
+            meta["pred_depth"], field="pred_depth"
+        )
         gates.append(
             {
                 "name": "pred_depth",
@@ -151,7 +219,9 @@ def run_doctor(
         )
 
     if expected_embed is not None and meta["embed_dim"] is not None:
-        ok = int(expected_embed) == int(meta["embed_dim"])
+        ok = _safe_int(expected_embed, field="embed_dim") == _safe_int(
+            meta["embed_dim"], field="embed_dim"
+        )
         gates.append(
             {
                 "name": "embed_dim",
@@ -191,7 +261,15 @@ def run_doctor(
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="V-JEPA 2.1 checkpoint/config doctor")
+    parser = argparse.ArgumentParser(
+        description="V-JEPA 2.1 checkpoint/config doctor",
+        epilog=(
+            "Security: only inspect checkpoint files from trusted sources. "
+            "Deserializing untrusted .pt files can execute arbitrary code when "
+            "weights_only=True is not sufficient."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("--checkpoint", type=Path, required=True)
     parser.add_argument("--config", type=Path, required=True)
     parser.add_argument("--json", action="store_true")

--- a/tests/scripts/test_vjepa2_doctor.py
+++ b/tests/scripts/test_vjepa2_doctor.py
@@ -1,18 +1,22 @@
 """Tests for scripts/vjepa2_doctor.py"""
 
-import json
 import sys
 from pathlib import Path
 
+import pytest
 import torch
 import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from vjepa2_doctor import infer_crop_size, inspect_checkpoint, run_doctor  # noqa: E402
-
-FIXTURES = Path(__file__).resolve().parent / "fixtures" / "doctor"
+from vjepa2_doctor import (  # noqa: E402
+    _get_config_value,
+    infer_crop_size,
+    infer_embed_dim,
+    inspect_checkpoint,
+    run_doctor,
+)
 
 
 def _write_ckpt(path: Path, *, crop_tokens: int, pred_blocks: int, embed_dim: int = 64):
@@ -37,6 +41,24 @@ def _write_cfg(path: Path, *, crop_size: int, pred_depth: int, embed_dim: int = 
 def test_infer_crop_size_from_pos_embed():
     state = {"pos_embed": torch.zeros(1, 24 * 24, 32)}
     assert infer_crop_size(state, patch_size=16) == 384
+
+
+def test_infer_crop_size_returns_first_valid_pos_embed():
+    encoder = {"pos_embed": torch.zeros(1, 16 * 16, 32)}
+    predictor = {"predictor.pos_embed": torch.zeros(1, 24 * 24, 32)}
+    state = {**encoder, **predictor}
+    assert infer_crop_size(state, patch_size=16) == 256
+
+
+def test_infer_embed_dim_from_pos_embed():
+    state = {"blocks.0.pos_embed": torch.zeros(1, 16 * 16, 128)}
+    assert infer_embed_dim(state) == 128
+
+
+def test_get_config_value_preserves_zero():
+    cfg = {"data": {"crop_size": 0}, "model": {"pred_depth": 0}}
+    assert _get_config_value(cfg, "data", "crop_size", flat_key="crop_size") == 0
+    assert _get_config_value(cfg, "model", "pred_depth", flat_key="pred_depth") == 0
 
 
 def test_doctor_passes_matching_config(tmp_path):
@@ -67,6 +89,18 @@ def test_doctor_fails_pred_depth_mismatch(tmp_path):
     _write_cfg(cfg, crop_size=256, pred_depth=24)
     report = run_doctor(ckpt, cfg)
     assert not report["passed"]
+
+
+def test_doctor_rejects_non_integer_crop_size(tmp_path):
+    ckpt = tmp_path / "ck.pt"
+    cfg = tmp_path / "cfg.yaml"
+    _write_ckpt(ckpt, crop_tokens=16, pred_blocks=4)
+    cfg.write_text(
+        yaml.dump({"data": {"crop_size": "384px"}, "model": {"pred_depth": 4, "patch_size": 16}}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="crop_size"):
+        run_doctor(ckpt, cfg)
 
 
 def test_inspect_checkpoint_keys(tmp_path):

--- a/tests/scripts/test_vjepa2_doctor.py
+++ b/tests/scripts/test_vjepa2_doctor.py
@@ -1,0 +1,77 @@
+"""Tests for scripts/vjepa2_doctor.py"""
+
+import json
+import sys
+from pathlib import Path
+
+import torch
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from vjepa2_doctor import infer_crop_size, inspect_checkpoint, run_doctor  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "doctor"
+
+
+def _write_ckpt(path: Path, *, crop_tokens: int, pred_blocks: int, embed_dim: int = 64):
+    n = crop_tokens * crop_tokens
+    encoder = {"pos_embed": torch.zeros(1, n, embed_dim)}
+    predictor = {}
+    for i in range(pred_blocks):
+        predictor[f"blocks.{i}.weight"] = torch.zeros(1)
+    ckpt = {"ema_encoder": encoder, "encoder": encoder, "predictor": predictor}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(ckpt, path)
+
+
+def _write_cfg(path: Path, *, crop_size: int, pred_depth: int, embed_dim: int = 64):
+    data = {
+        "data": {"crop_size": crop_size},
+        "model": {"pred_depth": pred_depth, "embed_dim": embed_dim, "patch_size": 16},
+    }
+    path.write_text(yaml.dump(data), encoding="utf-8")
+
+
+def test_infer_crop_size_from_pos_embed():
+    state = {"pos_embed": torch.zeros(1, 24 * 24, 32)}
+    assert infer_crop_size(state, patch_size=16) == 384
+
+
+def test_doctor_passes_matching_config(tmp_path):
+    ckpt = tmp_path / "ok.pt"
+    cfg = tmp_path / "ok.yaml"
+    _write_ckpt(ckpt, crop_tokens=24, pred_blocks=12)
+    _write_cfg(cfg, crop_size=384, pred_depth=12)
+    report = run_doctor(ckpt, cfg)
+    assert report["passed"]
+    assert all(g["passed"] for g in report["gates"] if not g.get("skipped"))
+
+
+def test_doctor_fails_crop_mismatch(tmp_path):
+    ckpt = tmp_path / "bad.pt"
+    cfg = tmp_path / "bad.yaml"
+    _write_ckpt(ckpt, crop_tokens=24, pred_blocks=12)  # 384
+    _write_cfg(cfg, crop_size=256, pred_depth=12)
+    report = run_doctor(ckpt, cfg)
+    assert not report["passed"]
+    crop = next(g for g in report["gates"] if g["name"] == "crop_size")
+    assert not crop["passed"]
+
+
+def test_doctor_fails_pred_depth_mismatch(tmp_path):
+    ckpt = tmp_path / "depth.pt"
+    cfg = tmp_path / "depth.yaml"
+    _write_ckpt(ckpt, crop_tokens=16, pred_blocks=12)
+    _write_cfg(cfg, crop_size=256, pred_depth=24)
+    report = run_doctor(ckpt, cfg)
+    assert not report["passed"]
+
+
+def test_inspect_checkpoint_keys(tmp_path):
+    ckpt = tmp_path / "keys.pt"
+    _write_ckpt(ckpt, crop_tokens=16, pred_blocks=4)
+    meta = inspect_checkpoint(ckpt)
+    assert meta["has_ema_encoder"]
+    assert meta["pred_depth"] == 4


### PR DESCRIPTION
## Problem

Continued pretraining from released V-JEPA 2.1 distilled checkpoints can fail silently when the training YAML does not match checkpoint metadata — e.g. crop_size 384 in the checkpoint vs 256 in cooldown config, or pred_depth 12 in checkpoint vs 24 in config (#163, #149).

## Repro

1. Download `vjepa2_1_vitl_dist_vitG_384.pt`
2. Use `configs/train_2_1/vitl16/cooldown-256px-64f.yaml` as-is
3. `crop_size` and `pred_depth` do not match the released weights → partial load / wrong resolution / NaN loss

## Fix

- `scripts/vjepa2_doctor.py` — inspects checkpoint top-level keys, infers `crop_size` from encoder `pos_embed`, counts predictor blocks, compares to YAML
- README section with usage
- `tests/scripts/test_vjepa2_doctor.py` — synthetic checkpoint fixtures

## Verification

```bash
python -m pytest tests/scripts/test_vjepa2_doctor.py -v
python scripts/vjepa2_doctor.py --checkpoint <path>.pt --config configs/train_2_1/vitl16/cooldown-256px-64f.yaml
```

Closes #163