### PR TITLE
Avoid duplicate encoder in V-JEPA2-AC training

### DIFF
--- a/app/vjepa_droid/train.py
+++ b/app/vjepa_droid/train.py
@@ -17,7 +17,6 @@ try:
 except Exception:
     pass
 
-import copy
 import gc
 import random
 import time
@@ -144,7 +143,6 @@ def main(args, resume_preempt=False):
     start_lr = cfgs_opt.get("start_lr")
     lr = cfgs_opt.get("lr")
     final_lr = cfgs_opt.get("final_lr")
-    enc_lr_scale = cfgs_opt.get("enc_lr_scale", 1.0)
     betas = cfgs_opt.get("betas", (0.9, 0.999))
     eps = cfgs_opt.get("eps", 1.0e-8)
     # ----------------------------------------------------------------------- #
@@ -189,7 +187,7 @@ def main(args, resume_preempt=False):
     )
 
     # -- init model
-    encoder, predictor = init_video_model(
+    target_encoder, predictor = init_video_model(
         uniform_power=uniform_power,
         device=device,
         patch_size=patch_size,
@@ -210,12 +208,9 @@ def main(args, resume_preempt=False):
         use_rope=use_rope,
         use_activation_checkpointing=use_activation_checkpointing,
     )
-    target_encoder = copy.deepcopy(encoder)
-
     if compile_model:
-        logger.info("Compiling encoder, target_encoder, and predictor.")
+        logger.info("Compiling target_encoder and predictor.")
         torch._dynamo.config.optimize_ddp = False
-        encoder.compile()
         target_encoder.compile()
         predictor.compile()
 
@@ -255,14 +250,12 @@ def main(args, resume_preempt=False):
 
     # -- init optimizer and scheduler
     optimizer, scaler, scheduler, wd_scheduler = init_opt(
-        encoder=encoder,
         predictor=predictor,
         wd=wd,
         final_wd=final_wd,
         start_lr=start_lr,
         ref_lr=lr,
         final_lr=final_lr,
-        enc_lr_scale=enc_lr_scale,
         iterations_per_epoch=ipe,
         anneal=anneal,
         warmup=warmup,
@@ -271,16 +264,15 @@ def main(args, resume_preempt=False):
         betas=betas,
         eps=eps,
     )
-    encoder = DistributedDataParallel(encoder, static_graph=True)
     predictor = DistributedDataParallel(predictor, static_graph=False, find_unused_parameters=True)
     target_encoder = DistributedDataParallel(target_encoder)
     for p in target_encoder.parameters():
         p.requires_grad = False
 
     # -- looad pretrained weights
-    encoder, predictor, target_encoder = load_pretrained(
+    _, predictor, target_encoder = load_pretrained(
         r_path=p_file,
-        encoder=encoder,
+        encoder=None,
         predictor=predictor,
         context_encoder_key=context_encoder_key,
         target_encoder_key=target_encoder_key,
@@ -293,7 +285,7 @@ def main(args, resume_preempt=False):
     # -- load training checkpoint
     if os.path.exists(latest_path):
         (
-            encoder,
+            _,
             predictor,
             target_encoder,
             optimizer,
@@ -301,7 +293,7 @@ def main(args, resume_preempt=False):
             start_epoch,
         ) = load_checkpoint(
             r_path=resume_path,
-            encoder=encoder,
+            encoder=None,
             predictor=predictor,
             target_encoder=target_encoder,
             opt=optimizer,
@@ -314,12 +306,14 @@ def main(args, resume_preempt=False):
     def save_checkpoint(epoch, path):
         if rank != 0:
             return
+        encoder_state_dict = target_encoder.state_dict()
         save_dict = {
-            "encoder": encoder.state_dict(),
+            # Keep both keys for compatibility with existing V-JEPA 2 tooling.
+            "encoder": encoder_state_dict,
             "predictor": predictor.state_dict(),
             "opt": optimizer.state_dict(),
             "scaler": None if scaler is None else scaler.state_dict(),
-            "target_encoder": target_encoder.state_dict(),
+            "target_encoder": encoder_state_dict,
             "epoch": epoch,
             "loss": loss_meter.avg,
             "batch_size": batch_size,

--- a/app/vjepa_droid/utils.py
+++ b/app/vjepa_droid/utils.py
@@ -19,6 +19,22 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger()
 
 
+def _migrate_predictor_optimizer_state(optimizer_state, num_param_groups):
+    """Drop the unused encoder groups from pre-fix V-JEPA2-AC checkpoints."""
+    if num_param_groups != 2 or len(optimizer_state["param_groups"]) != 4:
+        return optimizer_state
+
+    predictor_groups = [optimizer_state["param_groups"][1], optimizer_state["param_groups"][3]]
+    predictor_param_ids = {param_id for group in predictor_groups for param_id in group["params"]}
+    return {
+        **optimizer_state,
+        "state": {
+            param_id: state for param_id, state in optimizer_state["state"].items() if param_id in predictor_param_ids
+        },
+        "param_groups": predictor_groups,
+    }
+
+
 def load_pretrained(
     r_path,
     encoder=None,
@@ -34,7 +50,7 @@ def load_pretrained(
 
     epoch = checkpoint["epoch"]
 
-    if load_encoder:
+    if load_encoder and encoder is not None:
         # -- loading encoder
         pretrained_dict = checkpoint[context_encoder_key]
         pretrained_dict = {k.replace("backbone.", ""): v for k, v in pretrained_dict.items()}
@@ -80,12 +96,13 @@ def load_checkpoint(
 
     epoch = checkpoint["epoch"]
 
-    # -- loading encoder
-    pretrained_dict = checkpoint["encoder"]
-    for kw in replace_kw:
-        pretrained_dict = {k.replace(kw, ""): v for k, v in pretrained_dict.items()}
-    msg = encoder.load_state_dict(pretrained_dict, strict=False)
-    logger.info(f"loaded pretrained encoder from epoch {epoch} with msg: {msg}")
+    if encoder is not None:
+        # -- loading encoder
+        pretrained_dict = checkpoint["encoder"]
+        for kw in replace_kw:
+            pretrained_dict = {k.replace(kw, ""): v for k, v in pretrained_dict.items()}
+        msg = encoder.load_state_dict(pretrained_dict, strict=False)
+        logger.info(f"loaded pretrained encoder from epoch {epoch} with msg: {msg}")
 
     # -- loading predictor
     pretrained_dict = checkpoint["predictor"]
@@ -105,7 +122,8 @@ def load_checkpoint(
 
     # -- loading optimizer
     if opt is not None:
-        opt.load_state_dict(checkpoint["opt"])
+        optimizer_state = _migrate_predictor_optimizer_state(checkpoint["opt"], len(opt.param_groups))
+        opt.load_state_dict(optimizer_state)
 
     if scaler is not None:
         scaler.load_state_dict(checkpoint["scaler"])
@@ -195,7 +213,6 @@ def init_video_model(
 
 
 def init_opt(
-    encoder,
     predictor,
     iterations_per_epoch,
     start_lr,
@@ -210,21 +227,10 @@ def init_opt(
     betas=(0.9, 0.999),
     eps=1e-8,
     zero_init_bias_wd=True,
-    enc_lr_scale=1.0,
 ):
     param_groups = [
         {
-            "params": (p for n, p in encoder.named_parameters() if ("bias" not in n) and (len(p.shape) != 1)),
-            "lr_scale": enc_lr_scale,
-        },
-        {
             "params": (p for n, p in predictor.named_parameters() if ("bias" not in n) and (len(p.shape) != 1)),
-        },
-        {
-            "params": (p for n, p in encoder.named_parameters() if ("bias" in n) or (len(p.shape) == 1)),
-            "WD_exclude": zero_init_bias_wd,
-            "weight_decay": 0,
-            "lr_scale": enc_lr_scale,
         },
         {
             "params": (p for n, p in predictor.named_parameters() if ("bias" in n) or (len(p.shape) == 1)),

--- a/tests/test_vjepa_droid_utils.py
+++ b/tests/test_vjepa_droid_utils.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from app.vjepa_droid.utils import _migrate_predictor_optimizer_state, init_opt
+
+
+def test_predictor_optimizer_excludes_frozen_encoder_parameters():
+    predictor = torch.nn.Linear(4, 3)
+
+    optimizer, _, _, _ = init_opt(
+        predictor=predictor,
+        iterations_per_epoch=2,
+        start_lr=1e-4,
+        ref_lr=1e-3,
+        warmup=1,
+        anneal=1,
+        num_epochs=2,
+    )
+
+    optimized_parameters = {id(param) for group in optimizer.param_groups for param in group["params"]}
+    assert optimized_parameters == {id(param) for param in predictor.parameters()}
+    assert len(optimizer.param_groups) == 2
+
+
+def test_migrate_predictor_optimizer_state_from_four_groups():
+    optimizer_state = {
+        "state": {index: {"step": index} for index in range(6)},
+        "param_groups": [
+            {"params": [0, 1]},
+            {"params": [2, 3]},
+            {"params": [4]},
+            {"params": [5]},
+        ],
+    }
+
+    migrated = _migrate_predictor_optimizer_state(optimizer_state, num_param_groups=2)
+
+    assert [group["params"] for group in migrated["param_groups"]] == [[2, 3], [5]]
+    assert set(migrated["state"]) == {2, 3, 5}
+
+
+def test_migrated_state_loads_into_predictor_only_optimizer():
+    old_encoder = torch.nn.Linear(4, 3)
+    old_predictor = torch.nn.Linear(4, 3)
+    old_optimizer = torch.optim.AdamW(
+        [
+            {"params": [old_encoder.weight]},
+            {"params": [old_predictor.weight]},
+            {"params": [old_encoder.bias], "weight_decay": 0},
+            {"params": [old_predictor.bias], "weight_decay": 0},
+        ]
+    )
+    for param in [*old_encoder.parameters(), *old_predictor.parameters()]:
+        param.grad = torch.ones_like(param)
+    old_optimizer.step()
+
+    new_predictor = torch.nn.Linear(4, 3)
+    new_optimizer, _, _, _ = init_opt(
+        predictor=new_predictor,
+        iterations_per_epoch=2,
+        start_lr=1e-4,
+        ref_lr=1e-3,
+        warmup=1,
+        anneal=1,
+        num_epochs=2,
+    )
+    migrated = _migrate_predictor_optimizer_state(
+        old_optimizer.state_dict(), num_param_groups=len(new_optimizer.param_groups)
+    )
+
+    new_optimizer.load_state_dict(migrated)
+
+    assert len(new_optimizer.state) == len(list(new_predictor.parameters()))


### PR DESCRIPTION
Fixes #144.

## Summary

- use the single encoder returned by `init_video_model` as the frozen target encoder for V-JEPA2-AC training
- stop deep-copying, compiling, DDP-wrapping, and adding an unused context encoder to the optimizer
- preserve both `encoder` and `target_encoder` checkpoint keys for compatibility
- migrate legacy four-group optimizer states by retaining the two predictor groups, so existing runs can resume with their Adam moments
- add regression tests for predictor-only optimization and legacy optimizer-state migration

## Why

The V-JEPA2-AC training step only calls `target_encoder`; the separate `encoder` never participates in a forward or backward pass. Nevertheless, the official path deep-copied it onto the GPU and carried it through compilation, DDP, the optimizer, and checkpoints. For the official ViT-G configuration this is an unused copy of a 1B-parameter encoder.

The target representation and predictor loss path are unchanged: the same pretrained target-encoder weights are loaded and kept frozen. The change only removes the unused duplicate and its optimizer groups.

## Validation

- `python -m pytest tests/test_vjepa_droid_utils.py -q` — 3 passed
- `python -m pytest tests/models -q` — 12 passed, 3 skipped
- `flake8 app/vjepa_droid/train.py app/vjepa_droid/utils.py tests/test_vjepa_droid_utils.py`
- `black --check app/vjepa_droid/utils.py tests/test_vjepa_droid_utils.py`
- Python 3.12 Linux compile check