### PR TITLE
Fix random crop offset bounds

### DIFF
--- a/src/datasets/utils/video/transforms.py
+++ b/src/datasets/utils/video/transforms.py
@@ -135,10 +135,10 @@ def random_crop(images, size, boxes=None):
     width = images.shape[3]
     y_offset = 0
     if height > size:
-        y_offset = int(np.random.randint(0, height - size))
+        y_offset = int(np.random.randint(0, height - size + 1))
     x_offset = 0
     if width > size:
-        x_offset = int(np.random.randint(0, width - size))
+        x_offset = int(np.random.randint(0, width - size + 1))
     cropped = images[:, :, y_offset : y_offset + size, x_offset : x_offset + size]
 
     cropped_boxes = crop_boxes(boxes, x_offset, y_offset) if boxes is not None else None

--- a/tests/datasets/test_vjepa_transforms.py
+++ b/tests/datasets/test_vjepa_transforms.py
@@ -4,12 +4,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from unittest import mock
 
 import numpy as np
 import torch
 
 from app.vjepa import transforms
 from src.datasets.utils.video import functional
+from src.datasets.utils.video import transforms as video_transforms
 from src.datasets.utils.video.volume_transforms import ClipToTensor
 
 
@@ -49,6 +51,18 @@ class TestVideoTransformFunctionalCrop(unittest.TestCase):
 
         for clip_tensor, clip_np in zip(cropped_tensor, cropped_np_array):
             torch.testing.assert_close(clip_tensor, torch.Tensor(clip_np).to(dtype=torch.uint8))
+
+
+class TestVideoTransformRandomCrop(unittest.TestCase):
+    def test_includes_last_valid_crop_position(self):
+        images = torch.arange(24).reshape(1, 1, 4, 6)
+
+        with mock.patch.object(video_transforms.np.random, "randint", side_effect=[2, 4]) as mock_randint:
+            cropped, cropped_boxes = video_transforms.random_crop(images, size=2)
+
+        self.assertEqual(mock_randint.call_args_list, [mock.call(0, 3), mock.call(0, 5)])
+        torch.testing.assert_close(cropped, images[:, :, 2:4, 4:6])
+        self.assertIsNone(cropped_boxes)
 
 
 class TestVideoTransformFunctionalResize(unittest.TestCase):


### PR DESCRIPTION
## Summary

- include the final valid vertical and horizontal offsets in `random_crop`
- add regression coverage for the bottom-right crop position

Fixes #181

## Testing

- focused NumPy regression validation for the corrected offset bounds and crop result
- Python syntax compilation for both modified files
- `git diff --check`
- verified modified lines comply with the repository's 119-character limit

## Limitations

- The repository unit test and formatter commands were not run locally because PyTorch and the development tools are not installed in the available environment.